### PR TITLE
Make keypair clonable

### DIFF
--- a/src/ecc608/mod.rs
+++ b/src/ecc608/mod.rs
@@ -16,6 +16,7 @@ use std::{
 static INIT: Once = Once::new();
 static ECC: Mutex<Option<Ecc>> = Mutex::new(None);
 
+#[derive(Clone)]
 pub struct Keypair {
     pub network: Network,
     pub public_key: public_key::PublicKey,

--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -14,6 +14,7 @@ pub struct SharedSecret(pub(crate) p256::ecdh::SharedSecret);
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Signature(pub(crate) ecdsa::Signature);
 
+#[derive(Clone)]
 pub struct Keypair {
     pub network: Network,
     pub public_key: public_key::PublicKey,

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -7,6 +7,7 @@ pub struct PublicKey(pub(crate) ed25519_compact::PublicKey);
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Signature(ed25519_compact::Signature);
 
+#[derive(Clone)]
 pub struct Keypair {
     pub network: Network,
     pub public_key: public_key::PublicKey,

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -13,7 +13,7 @@ pub trait Sign {
 ///
 /// This enum acts as a type-erased wrapper for all supported keypair types (e.g., Ed25519, Secp256k1, ECC Compact, etc.),
 /// allowing generic handling of key generation, signing, and public key extraction.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Keypair {
     Secp256k1(secp256k1::Keypair),
     Ed25519(ed25519::Keypair),

--- a/src/nova_tz/mod.rs
+++ b/src/nova_tz/mod.rs
@@ -20,6 +20,7 @@ pub enum Error {
     QseecomError(#[from] io::Error),
 }
 
+#[derive(Clone)]
 pub struct Keypair {
     pub network: Network,
     pub public_key: public_key::PublicKey,

--- a/src/nova_tz/rsa_key.rs
+++ b/src/nova_tz/rsa_key.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::Path;
 use uuid::Uuid;
 
+#[derive(Clone)]
 pub struct TzRsaKeyInfo {
     key_name: String,
     rsa_key: RSAPublicKey,

--- a/src/rsa/mod.rs
+++ b/src/rsa/mod.rs
@@ -13,6 +13,7 @@ pub struct PublicKey(pub(crate) RSAPublicKey);
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Signature(pub(crate) Vec<u8>);
 
+#[derive(Clone)]
 pub struct Keypair {
     pub network: Network,
     pub public_key: public_key::PublicKey,

--- a/src/secp256k1/mod.rs
+++ b/src/secp256k1/mod.rs
@@ -10,6 +10,7 @@ pub struct PublicKey(k256::PublicKey);
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Signature(ecdsa::Signature);
 
+#[derive(Clone)]
 pub struct Keypair {
     pub network: Network,
     pub public_key: public_key::PublicKey,

--- a/src/tpm/mod.rs
+++ b/src/tpm/mod.rs
@@ -32,7 +32,7 @@ impl From<tss_esapi::Error> for Error {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct KeypairHandle {
     pub network: Network,
     pub public_key: public_key::PublicKey,


### PR DESCRIPTION
## Motivation
We usually store the keypair in settings.rs. Since the keypair type does not implement Clone, we were forced to wrap it in Arc throughout the project.