### PR TITLE
Add std feature to signature crate and re-export signature module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1"
 bs58 = { version = "0.5", features = ["check"] }
 base64 = ">=0.21"
 drop_guard = { version = "0.3.0", optional = true }
-signature = "2"
+signature = { version = "2", features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 rand_core = "^0.6"
 sha2 = { version = "0.10", default-features = false, features = ["std", "oid"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,11 @@ pub mod public_key;
 pub mod public_key_binary;
 
 mod keypair;
-
 pub use error::{Error, Result};
 pub use keypair::{Keypair, Sign};
 pub use public_key::{PublicKey, PublicKeySize, Verify};
 pub use public_key_binary::PublicKeyBinary;
+pub use signature;
 use std::{
     convert::{From, TryFrom, TryInto},
     fmt,


### PR DESCRIPTION
This fixes thiserror compatibility by enabling the std feature on the signature crate, which provides the std::error::Error implementation.

Also re-exports the signature module so downstream crates can use helium_crypto::signature::Error.