### PR TITLE
fix(crypto): correct secp256k1 read_from panic; tighten deprecation suppressions

### DIFF
--- a/src/ecc608/mod.rs
+++ b/src/ecc608/mod.rs
@@ -1,4 +1,6 @@
-// p256 0.13 GenericArray::from_slice deprecation; allow until upgrade.
+// See the matching comment in `src/ecc_compact/mod.rs` — generic-array
+// 0.14.9 is crate-level deprecated; this module reaches it via `p256 0.13`.
+// Migration waits on `p256 0.14` shipping stable.
 #![allow(deprecated)]
 
 use crate::{
@@ -104,7 +106,7 @@ impl Keypair {
         let shared_secret_bytes =
             with_ecc(|ecc| ecc.ecdh(self.slot, point.x().unwrap(), point.y().unwrap()))?;
         Ok(ecc_compact::SharedSecret(p256::ecdh::SharedSecret::from(
-            *p256::FieldBytes::from_slice(&shared_secret_bytes),
+            p256::FieldBytes::clone_from_slice(&shared_secret_bytes),
         )))
     }
 }

--- a/src/ecc_compact/mod.rs
+++ b/src/ecc_compact/mod.rs
@@ -1,6 +1,11 @@
-// p256 0.13 still uses generic-array 0.x, whose `as_slice` and
-// `from_slice` methods are deprecated. Crate-wide allow until p256
-// upgrades.
+// `generic-array 0.14.9`'s build script unconditionally annotates the crate
+// with `#![deprecated(note = "please upgrade to generic-array 1.x")]`, so
+// every item reachable through `p256 0.13` (which transitively re-exports
+// generic-array 0.14) trips the lint — including `AsRef<[u8]>`, `From`
+// impls, and the typed `FieldBytes` alias. The migration runs through
+// `p256 0.14` (which moves to `hybrid-array`), but that release is still
+// RC-only as of this commit; pulling an RC into a foundational crypto
+// crate is the wrong trade-off. Revisit when `p256 0.14` ships stable.
 #![allow(deprecated)]
 
 use crate::*;
@@ -130,7 +135,8 @@ impl Keypair {
     }
 
     pub fn secret_to_vec(&self) -> Vec<u8> {
-        self.secret.to_bytes().as_slice().to_vec()
+        // GenericArray<u8, U32> derefs to [u8]; resolve `to_vec` via that.
+        self.secret.to_bytes().to_vec()
     }
 
     pub fn ecdh<'a, C>(&self, public_key: C) -> Result<SharedSecret>
@@ -219,7 +225,7 @@ impl ReadFrom for PublicKey {
     fn read_from<R: std::io::Read>(input: &mut R) -> Result<Self> {
         let mut buf = [0u8; PUBLIC_KEY_LENGTH - 1];
         input.read_exact(&mut buf)?;
-        match p256::AffinePoint::decompact(FieldBytes::from_slice(&buf)).into() {
+        match p256::AffinePoint::decompact(&FieldBytes::from(buf)).into() {
             Some(point) => Ok(PublicKey(
                 p256::PublicKey::from_affine(point).map_err(Error::from)?,
             )),
@@ -351,9 +357,6 @@ mod tests {
         // And now do an ecdh with my keypair and the other public key and
         // compare it with the shared secret that the erlang ecdh generated
         let shared_secret = keypair.ecdh(&other_public_key).expect("shared secret");
-        assert_eq!(
-            shared_secret.raw_secret_bytes().as_slice(),
-            OTHER_SHARED_SECRET
-        );
+        assert_eq!(&shared_secret.raw_secret_bytes()[..], OTHER_SHARED_SECRET);
     }
 }

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -240,12 +240,11 @@ mod tests {
 
     #[test]
     #[cfg(feature = "solana")]
-    #[allow(deprecated)] // solana-keypair 2.3+ deprecates from_bytes; 2.2 has no TryFrom impl yet.
     fn solana_pubkey() {
         use solana_sdk::signature as solana_sdk;
         use std::convert::TryInto;
 
-        let solana_wallet = solana_sdk::Keypair::from_bytes(&BYTES[..]).unwrap();
+        let solana_wallet = solana_sdk::Keypair::try_from(&BYTES[..]).unwrap();
         let solana_pubkey = solana_sdk::Signer::pubkey(&solana_wallet);
 
         let entropy = &BYTES[..32];

--- a/src/secp256k1/mod.rs
+++ b/src/secp256k1/mod.rs
@@ -1,6 +1,7 @@
-// k256 0.13 still uses generic-array 0.x, whose `as_slice` and
-// `from_slice` methods are deprecated. Crate-wide allow until k256
-// upgrades.
+// See the matching comment in `src/ecc_compact/mod.rs` — generic-array
+// 0.14.9 is crate-level deprecated; `k256 0.13` transitively re-exports
+// it, so every reachable item trips the lint. Migration waits on
+// `k256 0.14` shipping stable.
 #![allow(deprecated)]
 
 use crate::*;
@@ -110,7 +111,8 @@ impl Keypair {
     }
 
     pub fn secret_to_vec(&self) -> Vec<u8> {
-        self.secret.to_bytes().as_slice().to_vec()
+        // GenericArray<u8, U32> derefs to [u8]; resolve `to_vec` via that.
+        self.secret.to_bytes().to_vec()
     }
 }
 
@@ -187,7 +189,13 @@ impl ReadFrom for PublicKey {
         use k256::elliptic_curve::sec1::FromEncodedPoint;
         let mut buf = [0u8; PUBLIC_KEY_LENGTH - 1];
         input.read_exact(&mut buf)?;
-        match k256::EncodedPoint::from_bytes(k256::FieldBytes::from_slice(&buf)).into() {
+        // `buf` holds the SEC1-compressed encoding (1 prefix byte + 32-byte X);
+        // pass it directly to `EncodedPoint::from_bytes`. The previous wrapping
+        // in `FieldBytes::from_slice` was a latent panic — `FieldBytes` is 32
+        // bytes (`GenericArray<u8, U32>`) and `from_slice` asserts equal length,
+        // so any 33-byte input would panic. The path is unreachable from
+        // current internal callers but is part of the public `ReadFrom` trait.
+        match k256::EncodedPoint::from_bytes(buf).into() {
             Some(Ok(point)) => Ok(PublicKey(
                 // If the encoded point did not projected onto the k256 curve, this unwrap would fail
                 k256::PublicKey::from_encoded_point(&point).unwrap(),
@@ -352,6 +360,22 @@ mod tests {
         const B58: &str = "1SpLY6fic4fGthLGjeAUdLVNVYk1gJGrWTGhsukm2dnELaSEQmhL";
         let decoded: crate::PublicKey = B58.parse().expect("b58 public key");
         assert_eq!(B58, decoded.to_string());
+    }
+
+    #[test]
+    fn read_from_roundtrip() {
+        // Exercises `crate::PublicKey::read_from` -> `secp256k1::PublicKey::read_from`,
+        // which previously wrapped the 33-byte SEC1 buffer in a 32-byte
+        // `FieldBytes` and would panic. The b58 path (`try_from`) does not
+        // hit that branch, so this is the only covering test.
+        use crate::{ReadFrom, WriteTo};
+        const B58: &str = "1SpLY6fic4fGthLGjeAUdLVNVYk1gJGrWTGhsukm2dnELaSEQmhL";
+        let original: crate::PublicKey = B58.parse().expect("b58 public key");
+        let mut buf = Vec::new();
+        original.write_to(&mut buf).expect("encode");
+        let mut cursor = std::io::Cursor::new(&buf[..]);
+        let decoded = crate::PublicKey::read_from(&mut cursor).expect("read_from");
+        assert_eq!(original, decoded);
     }
 
     #[test]

--- a/src/tpm/mod.rs
+++ b/src/tpm/mod.rs
@@ -1,4 +1,6 @@
-// p256 0.13 GenericArray::as_slice deprecation; allow until upgrade.
+// See the matching comment in `src/ecc_compact/mod.rs` — generic-array
+// 0.14.9 is crate-level deprecated; this module reaches it via `p256 0.13`.
+// Migration waits on `p256 0.14` shipping stable.
 #![allow(deprecated)]
 
 mod esys_wrapper;
@@ -94,8 +96,8 @@ impl KeypairHandle {
         use p256::elliptic_curve::sec1::ToEncodedPoint;
         let key = public_key.try_into()?;
         let point = key.0.to_encoded_point(false);
-        let x = point.x().unwrap().as_slice();
-        let y = point.y().unwrap().as_slice();
+        let x: &[u8] = point.x().unwrap().as_ref();
+        let y: &[u8] = point.y().unwrap().as_ref();
         let key_handle = self.handle;
 
         let mut shared_secret_bytes = vec![4u8];


### PR DESCRIPTION
## Summary

Three intertwined cleanups surfaced by `RUSTFLAGS=-D warnings` in CI combined with fresh dependency resolution.

### 1. Latent panic in `secp256k1::PublicKey::read_from`

The function reads a 33-byte SEC1-compressed public-key buffer and previously wrapped it in `k256::FieldBytes::from_slice(&buf)`. `FieldBytes` is `GenericArray<u8, U32>` (32 bytes); `from_slice` asserts `slice.len() == N` and panics on mismatch. **Any 33-byte input would panic, making this branch effectively unreachable.**

The path is reachable through the public `crate::PublicKey::read_from` API: a consumer that reads a serialized PublicKey (as written by `WriteTo`) would hit the panic. No internal callers exercise it — the b58/parse() route uses `TryFrom<&[u8]>` which is correct — so existing tests didn't catch it.

**Fix:** pass the 33 bytes straight to `EncodedPoint::from_bytes`, matching the existing `TryFrom<&[u8]>` implementation. Adds `read_from_roundtrip` test.

### 2. `solana_sdk::Keypair::from_bytes` deprecated → `try_from(&[u8])`

`solana-keypair 2.2.2` deprecated `from_bytes` in favor of the `TryFrom<&[u8]>` impl. The earlier ledger PR landed `from_bytes` + `#[allow(deprecated)]` because a stale local `Cargo.lock` was pinning 2.2.1 (where `TryFrom` didn't exist). Cargo.lock is gitignored for this library, so fresh resolution (CI, fresh clones) always picks the latest 2.2.x. Switching to `try_from` resolves the deprecation properly.

### 3. `#![allow(deprecated)]` suppressions: kept, with corrected root-cause comments

`generic-array 0.14.9`'s build script annotates the crate root with `#![deprecated]`. Every item reachable through `p256 0.13` / `k256 0.13` trips the lint — not just `as_slice`/`from_slice`, but `AsRef<[u8]>` impls, `From` impls, `FieldBytes`, etc. Switching APIs doesn't help; those impls live in the same deprecated crate.

The actual migration is `p256 0.14` / `k256 0.14`, which move to `hybrid-array`. Both are **RC-only** (`0.14.0-rc.9`). Pulling RC versions into a foundational crypto library is the wrong trade-off, so the `allow` annotations remain — but with rewritten comments that name the precise root cause and the condition for revisiting.

Cosmetic call-site cleanups landed alongside:
- `as_slice().to_vec()` → `to_vec()` (Deref<Target=[u8]>; drops one redundant call)
- `FieldBytes::from_slice(&buf)` → `&FieldBytes::from(buf)` where `buf: [u8; N]` matches `N` (compile-time-checked via `From<[T; N]>` rather than runtime-checked via `from_slice`'s `assert_eq!`)
- `point.x().unwrap().as_slice()` → explicit `let x: &[u8] = ... .as_ref()` in the TPM ECDH path (disambiguates the dual `AsRef<[u8]>` / `AsRef<[u8; N]>` impls)

## Verification

Local CI mode (no `Cargo.lock`, `RUSTFLAGS="-D warnings"`):
- `cargo clippy --features ledger,solana,rsa,ecc608,sqlx-postgres --lib --tests -- -D clippy::all` — clean
- `cargo test --features ledger,solana,rsa,ecc608,sqlx-postgres --lib` — **72 tests pass** (+1 vs main: `read_from_roundtrip`)
- `cargo fmt -- --check` — clean

TPM (`#[cfg(feature = "tpm")]`) cannot be built locally on darwin/aarch64 because `tss-esapi-sys` lacks prebuilt bindings. The TPM-touching changes (`point.x().as_ref()`) are mechanical 1:1 substitutions; CI's Linux job exercises the full `--all-features` build.