### PR TITLE
chore: revert manual version bump from #83, ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .envrc
 Cargo.lock
 *.profraw
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helium-crypto"
-version = "0.10.0"
+version = "0.9.4"
 authors = ["Marc Nijdam <marc@helium.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Restores the cargo-release flow that PR #83 inadvertently broke.

- **`chore: revert manual version bump from #83`** — sets `Cargo.toml` back to `0.9.4`. PR #83 manually bumped to `0.10.0`, but this project releases via `cargo release`, which owns the bump itself (see e.g. b19f227). With the manual bump in place, crates.io is still at 0.9.4 and there is no `v0.10.0` tag, so `cargo release minor` wants to skip 0.10.0 and publish 0.11.0. After this revert lands, `cargo release minor` from `main` will bump 0.9.4 → 0.10.0, publish, tag `v0.10.0`, and push — i.e. release 0.10.0 will include both #83 (multisig removal) and #84 (secp256k1 read_from fix).
- **`chore: ignore .DS_Store`** — macOS Finder drops these in browsed directories; they were showing as untracked and blocking `cargo release`'s clean-tree precondition.

## Yanked-dep warnings from `cargo release --dry-run`

Both are transitive and not actionable in this PR:

- `keccak 0.1.5` — pulled in via `sha3 0.10.8` in the solana 2.2.x stack (`solana-keccak-hasher`, `solana-secp256k1-program`). Upstream fix only; a library shouldn't ship `[patch.crates-io]`.
- `serialport 4.7.1` — pulled in via `ecc608-linux 0.2.3`, which is the latest published version of that crate. Needs a new `ecc608-linux` release that bumps to `serialport 4.9`.

No code paths are touched.