### PR TITLE
Tighten ecc608-linux spec to ^0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rsa = { version = "0.4", optional = true, default-features = false, features = [
   "std",
   "pem",
 ] }
-ecc608-linux = { version = "0", optional = true }
+ecc608-linux = { version = "0.2", optional = true }
 tss-esapi = { version = "7", optional = true }
 libc = { version = "0", optional = true }
 byteorder = { version = "1", optional = true }


### PR DESCRIPTION
## Summary
- Bumps the `ecc608-linux` dependency from `"0"` to `"0.2"` so fresh resolution can't drift back to older `0.1.x` releases.
- Pairs with the matching pin in `ecc608-linux-rs` so downstream `cargo release` runs land on a tested baseline and stop surfacing yanked transitive `serialport`/`keccak` entries from stale local lockfiles.